### PR TITLE
[Automated] Update academy-theme to v0.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.8 // indirect
+	github.com/layer5io/academy-theme v0.4.9 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,5 +22,7 @@ github.com/layer5io/academy-theme v0.4.7 h1:Wq1uaVZN04rXnrMgX2K37M2xr/yR0I6NiyOW
 github.com/layer5io/academy-theme v0.4.7/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.8 h1:K9BwfxjE5ieBA1/0qXjBHLMskQI6xZcQxmoWIxPtwR8=
 github.com/layer5io/academy-theme v0.4.8/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.9 h1:MQi5yZ2HmTzBVDZn+4CUuPRIxAlYCbwCOza4TUQUjtE=
+github.com/layer5io/academy-theme v0.4.9/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.9.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.