### PR TITLE
Cross-link the prep path and exam challenge to the DO-CAIE certification

### DIFF
--- a/content/challenges/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/docaie-certification-exam/_index.md
+++ b/content/challenges/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/docaie-certification-exam/_index.md
@@ -4,3 +4,11 @@ description: "The comprehensive certification exam for the DigitalOcean Certifie
 banner: "digitalocean.svg"
 id: "0182a038-cde4-4631-aa9a-e171b8b37194"
 ---
+
+This challenge delivers the two required parts of the
+[**DigitalOcean Certified AI Engineer (DO-CAIE)**](https://cloud.layer5.io/academy/certifications/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/digitalocean-certified-ai-engineer/)
+certification: the written **exam** and the hands-on **capstone** lab.
+
+New here? Start with the
+[DO-CAIE Certification Prep](https://cloud.layer5.io/academy/learning-paths/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/certified-ai-engineer/)
+learning path for the exam blueprint, a domain-by-domain study guide, and the capstone guide.

--- a/content/challenges/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/docaie-certification-exam/lab.md
+++ b/content/challenges/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/docaie-certification-exam/lab.md
@@ -6,7 +6,9 @@ title: "DO-CAIE Capstone & Certification"
 
 ## Introduction
 
-This is the capstone for the **DigitalOcean Certified AI Engineer (DO-CAIE)** credential. It brings
+This is the capstone for the
+[**DigitalOcean Certified AI Engineer (DO-CAIE)**](https://cloud.layer5.io/academy/certifications/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/digitalocean-certified-ai-engineer/)
+credential. It brings
 together everything in the academy: building a grounded agent on the
 [Gradient AI Platform](https://docs.digitalocean.com/products/gradient-ai-platform/), serving a model
 on GPU infrastructure, and operating it all with [Meshery](https://meshery.io/). You must pass both

--- a/content/learning-paths/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/certified-ai-engineer/capstone-project-guide/capstone/submission-process/_index.md
+++ b/content/learning-paths/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/certified-ai-engineer/capstone-project-guide/capstone/submission-process/_index.md
@@ -45,7 +45,9 @@ demo timestamps). This speeds review and helps you catch gaps before submitting.
 
 ## 4. Submit
 
-From the certification page, choose **Submit capstone** and provide:
+From the
+[DO-CAIE certification page](https://cloud.layer5.io/academy/certifications/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/digitalocean-certified-ai-engineer/),
+choose **Submit capstone** and provide:
 
 - the repository URL (public, or grant reviewer access),
 - the demo link,
@@ -63,5 +65,5 @@ From the certification page, choose **Submit capstone** and provide:
 - Keep the project alive: re-run Evaluations and Performance Profiles against newer models to stay
   sharp for **recertification**.
 
-Congratulations — completing the capstone is the final step toward becoming a **DigitalOcean
-Certified AI Engineer**.
+Congratulations — completing the capstone is the final step toward becoming a
+[**DigitalOcean Certified AI Engineer**](https://cloud.layer5.io/academy/certifications/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/digitalocean-certified-ai-engineer/).

--- a/content/learning-paths/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/certified-ai-engineer/certification-overview/overview/about-the-do-caie-certification/_index.md
+++ b/content/learning-paths/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/certified-ai-engineer/certification-overview/overview/about-the-do-caie-certification/_index.md
@@ -11,6 +11,11 @@ DigitalOcean Academy. It validates that you can design, build, serve, operate, a
 production AI applications on DigitalOcean's AI-Native Cloud — and that you can manage the
 underlying cloud native infrastructure with [Meshery](https://meshery.io/).
 
+> **This path is the study guide for the credential.** For the official competency blueprint,
+> prerequisites, and exam policies, see the
+> [DigitalOcean Certified AI Engineer (DO-CAIE) certification](https://cloud.layer5.io/academy/certifications/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/digitalocean-certified-ai-engineer/),
+> and take the [DO-CAIE Certification Exam](https://cloud.layer5.io/academy/challenges/3e2f9c82-1a4c-4781-adf9-99ec22cd994e/docaie-certification-exam/) when you are ready.
+
 ## Who it is for
 
 - **AI/ML engineers** building agentic and retrieval-augmented applications on the


### PR DESCRIPTION
## Overview

Follow-up to #51 (now merged). That PR added the first-class **DigitalOcean Certified AI Engineer (DO-CAIE)** certification entity. This PR adds the **bidirectional cross-links** between the certification and its supporting content — the cross-link commit landed on the branch just after #51 merged, so it needs its own PR to reach `master`.

## What's changed

The certification already points *to* the prep path and exam (via `prerequisite_knowledge` / `related_resources`). This wires the supporting content *back to* the certification:

- **Exam challenge overview** (`docaie-certification-exam/_index.md`) — now states it delivers the certification's written **exam** and hands-on **capstone**, and points newcomers to the prep path.
- **Capstone lab** (`docaie-certification-exam/lab.md`) — links the credential name to the certification page.
- **"About the DO-CAIE Certification"** lesson — adds a callout to the official certification page and the exam challenge.
- **Capstone submission process** — links "Submit capstone" and the closing line to the certification page.

All links use the registered content slugs under `…/certifications/3e2f9c82…/digitalocean-certified-ai-engineer/`.

## Validation

- Clean `hugo build` passes (exit 0) with **zero errors and zero registry warnings**.
- Cross-links render in the exam challenge, its lab, the submission-process lesson, and the about lesson.
