### PR TITLE
fix: update discussion links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,4 +29,4 @@ assignees: ''
 ---
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to digitalocean-academy](https://github.com/layer5io/digitalocean-academy/blob/master/CONTRIBUTING.md)
-- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://messhery.io/community#discussion-forums) and [Community Slack](http://slack.meshery.io)
+- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](http://slack.meshery.io)


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the community discussion forum link by replacing the [old URL](http://meshery.io/community#discussion-forums) with https://discuss.meshery.io.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
